### PR TITLE
chore: install.ps1のみBOMを削除

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,4 @@
-﻿# uvのプロジェクトとして作成されたPythonスクリプトを実行するPowerShellスクリプトのショートカットをデスクトップに作成する。
+# uvのプロジェクトとして作成されたPythonスクリプトを実行するPowerShellスクリプトのショートカットをデスクトップに作成する。
 
 Add-Type -AssemblyName System.Windows.Forms
 


### PR DESCRIPTION
`iex`に食わせる場合、BOMがない方が良い模様。