### PR TITLE
feat: `Runner`に各レーンの解析完了後のpostprocessを行う機能を追加

### DIFF
--- a/documents.md
+++ b/documents.md
@@ -13,7 +13,7 @@ matplotlib.figure.Figureを保存する。
 ## `class DefaultOutput`
 
 matplotlib.figure.Figureを保存する。
-shoe=Trueの場合、保存後にNotebookへの表示を実行する。
+show=Trueの場合、保存後にNotebookへの表示を実行する。
 
 ## `class AnalyzeArgs`
 
@@ -23,11 +23,18 @@ shoe=Trueの場合、保存後にNotebookへの表示を実行する。
 - `fields: scanner.Fields`: 対象となるレーンのデータを視野ごとに探索するためのスキャナー。
 - `output: Output`: 画像を保存するためのOutput実装。
 
+## `class PostprocessArgs`
+
+**メンバ変数**
+
+- `ctx: Context`: 解析全体に関わる情報を格納するコンテキストオブジェクト。
+- `analysis_results: pd.DataFrame`: 解析結果を格納したDataFrame。
+
 ## `class NotebookRunner`
 
 主にJupyter notebookでの使用を想定したrunner。
 
-### `NotebookRunner.run(ctx: Context, analyze: Callable[[AnalyzeArgs[Context]], pd.Series]) -> pd.DataFrame`
+### `NotebookRunner.run(ctx: Context, analyze: Callable[[AnalyzeArgs[Context]], pd.Series], postprocess: Optional[Callable[[PostprocessArgs[Context]], pd.DataFrame]]) -> pd.DataFrame`
 
 各レーンごとに画像解析を実行する。
 レーンごとの解析結果を結合したDataFrameを返す。
@@ -35,12 +42,13 @@ shoe=Trueの場合、保存後にNotebookへの表示を実行する。
 **引数**
 - `ctx: Context`: 解析全体に関わる情報を格納するコンテキストオブジェクト。
 - `analyze: Callable[[AnalyzeArgs[Context]], pd.Series]`: 解析関数。 解析関数はグローバル変数を参照してはならず、関数のなかで宣言された変数とコンテキストオブジェクトに格納した変数のみを参照すること。
+- `postprocess: Optional[Callable[[PostprocessArgs[Context]], pd.DataFrame]]`: 解析結果を後処理する関数。 レーンごとの解析結果を結合したDataFrameを受け取り、総合して結果を更新することができる。 更新したDataFrameは戻り値として返すこと。
 
 ## `class ParallelRunner`
 
 マルチプロセスで並列処理するrunner。
 
-### `ParallelRunner.run(ctx: Context, analyze: Callable[[AnalyzeArgs[Context]], pd.Series]) -> pd.DataFrame`
+### `ParallelRunner.run(ctx: Context, analyze: Callable[[AnalyzeArgs[Context]], pd.Series], postprocess: Optional[Callable[[PostprocessArgs[Context]], pd.DataFrame]]) -> pd.DataFrame`
 
 各レーンごとに画像解析を実行する。
 レーンごとの解析結果を結合したDataFrameを返す。
@@ -48,6 +56,7 @@ shoe=Trueの場合、保存後にNotebookへの表示を実行する。
 **引数**
 - `ctx: Context`: 解析全体に関わる情報を格納するコンテキストオブジェクト。
 - `analyze: Callable[[AnalyzeArgs[Context]], pd.Series]`: 解析関数。 解析関数はグローバル変数を参照してはならず、関数のなかで宣言された変数とコンテキストオブジェクトに格納した変数のみを参照すること。
+- `postprocess: Optional[Callable[[PostprocessArgs[Context]], pd.DataFrame]]`: 解析結果を後処理する関数。 レーンごとの解析結果を結合したDataFrameを受け取り、総合して結果を更新することができる。 更新したDataFrameは戻り値として返すこと。
 
 ---
 


### PR DESCRIPTION
Close #29 

`postprocess`関数を利用できるようにする (optional)。
```python
def analyze(args: AnalyzeArgs[Context]): -> pd.Series:
    ...

def postprocess(args: PostprocessArgs[Context]): -> pd.DataFrame:
    analysis_results = args.analysis_results
    analysis_results["more_info"] = "foo_bar"
    return analysis_results

r = ParallelRunner(...)
r.Run(ctx, analyze, postprocess)
```