### PR TITLE
fix: マングリングエラーとpickleエラーを解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## ライブラリ
 ### インストール方法
 ```shell
-$ uv add git+https://github.com/cosomil/analysisrun --tag v0.0.5
+$ uv add git+https://github.com/cosomil/analysisrun --tag v0.0.6
 ```
 ※適切なバージョン（タグ）を選択してください。
 ※GitHubで公開されたパッケージをインストールするためには、システムにGitがインストールされている必要があります。

--- a/src/analysisrun/runner.py
+++ b/src/analysisrun/runner.py
@@ -3,10 +3,12 @@ from dataclasses import dataclass
 from typing import (
     Callable,
     Generator,
+    Generic,
     Iterable,
     LiteralString,
     Optional,
     Protocol,
+    TypeVar,
 )
 
 import matplotlib.figure as fig
@@ -14,6 +16,8 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 from .scanner import CleansedData, Fields, Lanes
+
+Context = TypeVar("Context")
 
 
 class Output(Protocol):
@@ -59,7 +63,7 @@ class DefaultOutput:
 
 
 @dataclass
-class AnalyzeArgs[Context]:
+class AnalyzeArgs(Generic[Context]):
     ctx: Context
     """
     解析全体に関わる情報を格納するコンテキストオブジェクト
@@ -79,7 +83,7 @@ class AnalyzeArgs[Context]:
 
 
 @dataclass
-class PostprocessArgs[Context]:
+class PostprocessArgs(Generic[Context]):
     ctx: Context
     """
     解析全体に関わる情報を格納するコンテキストオブジェクト。
@@ -90,7 +94,7 @@ class PostprocessArgs[Context]:
     """
 
 
-class NotebookRunner[Context]:
+class NotebookRunner(Generic[Context]):
     """
     主にJupyter notebookでの使用を想定したrunner。
     """
@@ -165,7 +169,7 @@ class NotebookRunner[Context]:
         return _apply_postprocess(ctx, results, self._postprocess)
 
 
-class ParallelRunner[Context]:
+class ParallelRunner(Generic[Context]):
     """
     マルチプロセスで並列処理するrunner。
     """
@@ -241,7 +245,7 @@ class ParallelRunner[Context]:
         return _apply_postprocess(ctx, results, self._postprocess)
 
 
-def _analysis_args_generator[Context](
+def _analysis_args_generator(
     ctx: Context,
     target_data: list[str],
     whole_data: CleansedData,
@@ -278,7 +282,7 @@ def _analysis_args_generator[Context](
         )
 
 
-def _apply_postprocess[Context](
+def _apply_postprocess(
     ctx: Context,
     results: pd.DataFrame,
     postprocess: Optional[Callable[[PostprocessArgs[Context]], pd.DataFrame]],
@@ -298,5 +302,5 @@ def _apply_postprocess[Context](
 
 def _zip_unpacked[T](
     main: Iterable[T], supplemental: Iterable[Iterable[T]]
-) -> list[list[T]]:
-    return [[x, *others] for x, *others in zip(main, *supplemental)]
+) -> Generator[list[T]]:
+    return ([x, *others] for x, *others in zip(main, *supplemental))

--- a/src/analysisrun/runner.py
+++ b/src/analysisrun/runner.py
@@ -151,7 +151,7 @@ class NotebookRunner[Context]:
         results = pd.DataFrame(
             [
                 self._analyze(args)
-                for args in __analysis_args_generator(
+                for args in _analysis_args_generator(
                     ctx,
                     target_data,
                     whole_data,
@@ -162,7 +162,7 @@ class NotebookRunner[Context]:
             ]
         )
 
-        return __apply_postprocess(ctx, results, self._postprocess)
+        return _apply_postprocess(ctx, results, self._postprocess)
 
 
 class ParallelRunner[Context]:
@@ -227,7 +227,7 @@ class ParallelRunner[Context]:
             results = pd.DataFrame(
                 executor.map(
                     self._analyze,
-                    __analysis_args_generator(
+                    _analysis_args_generator(
                         ctx,
                         target_data,
                         whole_data,
@@ -238,10 +238,10 @@ class ParallelRunner[Context]:
                 )
             )
 
-        return __apply_postprocess(ctx, results, self._postprocess)
+        return _apply_postprocess(ctx, results, self._postprocess)
 
 
-def __analysis_args_generator[Context](
+def _analysis_args_generator[Context](
     ctx: Context,
     target_data: list[str],
     whole_data: CleansedData,
@@ -269,7 +269,7 @@ def __analysis_args_generator[Context](
         for data in data_for_enhancement
     )
 
-    for fields, *lane_for_enhancement in __zip_unpacked(lanes, lanes_for_enhancement):
+    for fields, *lane_for_enhancement in _zip_unpacked(lanes, lanes_for_enhancement):
         yield AnalyzeArgs[Context](
             ctx=ctx,
             fields=fields,
@@ -278,7 +278,7 @@ def __analysis_args_generator[Context](
         )
 
 
-def __apply_postprocess[Context](
+def _apply_postprocess[Context](
     ctx: Context,
     results: pd.DataFrame,
     postprocess: Optional[Callable[[PostprocessArgs[Context]], pd.DataFrame]],
@@ -296,7 +296,7 @@ def __apply_postprocess[Context](
     return results
 
 
-def __zip_unpacked[T](
+def _zip_unpacked[T](
     main: Iterable[T], supplemental: Iterable[Iterable[T]]
 ) -> list[list[T]]:
     return [[x, *others] for x, *others in zip(main, *supplemental)]


### PR DESCRIPTION
- 内部用関数の名前を"__"から始めたことでエラーが発生
  - 関数名の先頭を"_"に置換
- ジェネリクス構文を使用することで、ParallelRunnerでPickle化する際にエラーが発生していた
  - TypeVarを使用することでエラーを回避